### PR TITLE
Modified the enqueue behavior to be cache

### DIFF
--- a/admin/class-admin-options.php
+++ b/admin/class-admin-options.php
@@ -396,19 +396,19 @@ class Lazyload_Videos_Admin {
 
 	function lazyload_admin_js() {
 		if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-			wp_enqueue_script( 'lazyload_admin_js', plugins_url( '../js/admin.js' , __FILE__ ), array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
+			wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'js/admin.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
 		} else {
-			wp_enqueue_script( 'lazyload_admin_js', plugins_url( '../js/min/admin-ck.js' , __FILE__ ), array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
+			wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'js/min/admin-ck.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
 		}
 	}
 
 	function lazyload_admin_css() {
-		wp_enqueue_style( 'lazyload-admin-css', plugins_url('../css/min/admin.min.css', __FILE__) );
-		wp_enqueue_style( 'lazyload-admin-css-tooltips', plugins_url('../css/min/admin-tooltips.min.css', __FILE__) );
+		wp_enqueue_style( 'lazyload-admin-css', LL_URL . 'css/min/admin.min.css' );
+		wp_enqueue_style( 'lazyload-admin-css-tooltips', LL_URL . 'css/min/admin-tooltips.min.css' );
 		wp_enqueue_style( 'wp-color-picker' );	// Required for colour picker
 
 		if ( is_rtl() ) {
-			wp_enqueue_style( 'lazyload-admin-rtl', plugins_url('../css/min/admin-rtl.min.css', __FILE__) );
+			wp_enqueue_style( 'lazyload-admin-rtl', LL_URL . 'css/min/admin-rtl.min.css' );
 		}
 	}
 

--- a/codeispoetry.php
+++ b/codeispoetry.php
@@ -45,6 +45,10 @@ if ( !defined( 'LL_TD' ) ) {
 if ( !defined( 'LL_PATH' ) )
 	define( 'LL_PATH', plugin_dir_path( __FILE__ ) );
 
+if ( !defined( 'LL_URL' ) )
+	define( 'LL_URL', plugins_url( __FILE__ ) );
+
+
 require_once( LL_PATH . 'admin/inc/define.php' );
 require_once( LL_PATH . 'admin/class-register.php' );
 require_once( LL_PATH . 'inc/class-general.php' );

--- a/codeispoetry.php
+++ b/codeispoetry.php
@@ -46,7 +46,7 @@ if ( !defined( 'LL_PATH' ) )
 	define( 'LL_PATH', plugin_dir_path( __FILE__ ) );
 
 if ( !defined( 'LL_URL' ) )
-	define( 'LL_URL', plugins_url( __FILE__ ) );
+	define( 'LL_URL', plugin_dir_url( __FILE__ ) );
 
 
 require_once( LL_PATH . 'admin/inc/define.php' );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -19,9 +19,9 @@ class Lazyload_Videos_Frontend {
 	}
 	function enable_lazyload_js() {
 		if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-			wp_enqueue_script( 'lazyload-video-js', plugins_url( '../js/lazyload-video.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+			wp_enqueue_script( 'lazyload-video-js', LL_URL . 'js/lazyload-video.js', array( 'jquery' ), LL_VERSION );
 		} else {
-			wp_enqueue_script( 'lazyload-video-js', plugins_url( '../js/min/lazyload-video.min.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+			wp_enqueue_script( 'lazyload-video-js', LL_URL . 'js/min/lazyload-video.min.js', array( 'jquery' ), LL_VERSION );
 		} ?>
 		<script>
 		( function ( $ ) {

--- a/frontend/class-vimeo.php
+++ b/frontend/class-vimeo.php
@@ -20,9 +20,9 @@ class Lazyload_Video_Vimeo extends Lazyload_Videos_Frontend {
 	function enable_lazyload_js() {
 		if ( parent::test_if_scripts_should_be_loaded() && (get_option('llv_opt') !== '1') ) {
 			if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-				wp_enqueue_script( 'lazyload_vimeo_js', plugins_url( '../js/lazyload-vimeo.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+				wp_enqueue_script( 'lazyload_vimeo_js', LL_URL . 'js/lazyload-vimeo.js', array( 'jquery' ), LL_VERSION );
 			} else {
-				wp_enqueue_script( 'lazyload_vimeo_js', plugins_url( '../js/min/lazyload-vimeo.min.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+				wp_enqueue_script( 'lazyload_vimeo_js', LL_URL . 'js/min/lazyload-vimeo.min.js', array( 'jquery' ), LL_VERSION );
 			} ?>
 		    <script type='text/javascript'>
 		    (function ( $ ) {

--- a/frontend/class-youtube.php
+++ b/frontend/class-youtube.php
@@ -16,9 +16,9 @@ class Lazyload_Videos_Youtube extends Lazyload_Videos_Frontend {
 	function enable_lazyload_js() {
 		if ( parent::test_if_scripts_should_be_loaded() && (get_option('lly_opt') !== '1') ) {
 			if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-				wp_enqueue_script( 'lazyload_youtube_js', plugins_url( '../js/lazyload-youtube.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+				wp_enqueue_script( 'lazyload_youtube_js', LL_URL . 'js/lazyload-youtube.js', array( 'jquery' ), LL_VERSION );
 			} else {
-				wp_enqueue_script( 'lazyload_youtube_js', plugins_url( '../js/min/lazyload-youtube.min.js' , __FILE__ ), array( 'jquery' ), LL_VERSION );
+				wp_enqueue_script( 'lazyload_youtube_js', LL_URL . 'js/min/lazyload-youtube.min.js', array( 'jquery' ), LL_VERSION );
 			} ?>
 			<script>
 			(function ( $ ) {


### PR DESCRIPTION
The enqueue behavior was modified so the included scripts and styles use a properly formed url without traversing in and out of directories.

Before:
<script type="text/javascript" src="http://sigginet.info/wp-content/plugins/lazy-load-for-videos/frontend/../js/min/lazyload-youtube.min.js?ver=2.2.0.2"></script>

After:
http://sigginet.info/wp-content/plugins/lazy-load-for-videos/js/min/lazyload-youtube.min.js?ver=2.2.0.2

This makes the plugin "W3 Total Cache compatible" essentially

I've tested this update on my website and it works flawlessly