### PR TITLE
Improve embed detection; new filter for when to load scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-Lazy Load for Videos by [Kevin Weber](//www.kweber.com)
+Lazy Load for Videos by [Kevin Weber](https://www.kweber.com)
 ====================
 
 This plugin improves page load times and increases your Google PageSpeed Score. It replaces embedded Youtube and Vimeo videos with a clickable preview image.
 By loading the videos only when the user clicks on the preview image, no unnecessary JavaScript is loaded. Especially on sites with many embedded videos this will make your visitors happy.
 
-[Download link and more information on the developer's website](//www.kweber.com/lazy-load-videos/)
+[Download link and more information on the developer's website](https://www.kweber.com/lazy-load-videos/)
 
-## Who can contribute?
-Everyone. You! I'm looking forward to merge your contribution. Here are a few steps to help you get started:
+## How to contribute?
+This is open source. Everyone can contribute, including you! I'm looking forward to review and merge your contribution. Here are a few steps to help you get started:
 
 1. Fork/clone this repository to your computer.
 1. Navigate to your downloaded folder in your terminal.
@@ -16,3 +16,21 @@ Everyone. You! I'm looking forward to merge your contribution. Here are a few st
 1. Ideally, write tests related to your changes. Make sure that all test cases are succeeding (run: `npm run test`).
 1. When you're done, run `npm run production`.
 1. Create a [pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+## Integration with other themes and plugins
+
+### Filter: `lazyload_videos_should_scripts_be_loaded`
+
+You can override when the JS and CSS of this plugin should be loaded. If you always return `true` as shown in the example below, the scripts will always be loaded, no matter if the page has a video embed or not.
+
+```
+function custom_theme_plugin__should_scripts_be_loaded($value) {
+	// return $value;
+	return true; // <- Always load scripts, no matter what page you're on
+}
+add_filter( 'lazyload_videos_should_scripts_be_loaded', 'custom_theme_plugin__should_scripts_be_loaded');
+```
+
+### Filter: `lazyload_videos_post_types`
+
+The default set of post types where videos should be lazy-loaded comes from [get_post_types()](https://codex.wordpress.org/Function_Reference/get_post_types). Use this filter to extend/override the default.

--- a/admin/class-admin-options.php
+++ b/admin/class-admin-options.php
@@ -423,11 +423,7 @@ class Lazy_Load_For_Videos_Admin {
 	}
 
 	function lazyload_admin_js() {
-		if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-			wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'assets/js/admin.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
-		} else {
-			wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'assets/js/admin.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
-		}
+		wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'assets/js/admin.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
 	}
 
 	function lazyload_admin_css() {

--- a/admin/class-admin-options.php
+++ b/admin/class-admin-options.php
@@ -56,7 +56,7 @@ class Lazy_Load_For_Videos_Admin {
 
 		// If URL contains "lazyload=0", we don't want to lazyload it.
 		if (strpos($url, 'lazyload=0') !== false) {
-	    return $return;
+	    	return $return;
 		}
 
 		// Youtube support
@@ -190,7 +190,7 @@ class Lazy_Load_For_Videos_Admin {
 					        <tr valign="top">
 						        <th scope="row"><label><?php esc_html_e( 'Only load CSS/JS when needed', LL_TD ); ?><br><span class="description thin"><?php esc_html_e( 'to improve performance', LL_TD ); ?></span></label></th>
 						        <td>
-									<input name="ll_opt_load_scripts" type="checkbox" value="1" <?php checked( '1', get_option( 'll_opt_load_scripts' ) ); ?> /> <label><?php esc_html_e( 'It can happen that &ndash; when this option is checked &ndash; videos on pages do not lazy load although they should. It works on most sites. Simply test it.', LL_TD ); ?></label>
+									<input name="ll_opt_load_scripts" type="checkbox" value="1" <?php checked( '1', get_option( 'll_opt_load_scripts' ) ); ?> /> <label><?php esc_html_e( 'When this option is checked, some videos might not lazy load if posts with videos are loaded using Ajax.', LL_TD ); ?></label>
 						        </td>
 					        </tr>
 				        	<tr valign="top">
@@ -347,7 +347,13 @@ class Lazy_Load_For_Videos_Admin {
 					        <tr valign="top">
 						        <th scope="row"><label><?php esc_html_e( 'Disable Lazy Load for Vimeo', LL_TD ); ?></label></th>
 						        <td>
-									<input name="llv_opt" type="checkbox" value="1" <?php checked( '1', get_option( 'llv_opt' ) ); ?> /> <label><?php esc_html_e( 'If checked, Lazy Load will not be used for <b>Vimeo</b> videos.', LL_TD ); ?></label> <label><span style="color:#f60;"><?php esc_html_e( 'Important:', LL_TD ); ?></span> <?php esc_html_e( 'Updates on this option will only affect new posts and posts you update afterwards with the "Update Posts" button at the bottom of this form.', LL_TD ); ?></label>
+									<input name="llv_opt" type="checkbox" value="1" <?php checked( '1', get_option( 'llv_opt' ) ); ?> /> 
+									<label>
+										<?php printf( esc_html__( 'If checked, Lazy Load will not be used for %1$s videos.', LL_TD ),
+											'<b>Vimeo</b>'
+										); ?>
+									</label>
+									<label><span style="color:#f60;"><?php esc_html_e( 'Important:', LL_TD ); ?></span> <?php esc_html_e( 'Updates on this option will only affect new posts and posts you update afterwards with the "Update Posts" button at the bottom of this form.', LL_TD ); ?></label>
 						        </td>
 					        </tr>
 					        <tr valign="top">

--- a/codeispoetry.php
+++ b/codeispoetry.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.kweber.com/lazy-load-videos/
  * Description: Lazy Load for Videos speeds up your site by replacing embedded Youtube and Vimeo videos with a clickable preview image. Visitors simply click on the image to play the video.
  * Author: Kevin Weber
- * Version: 2.7.1
+ * Version: 2.7.2
  * Author URI: https://www.kweber.com/
  * License: GPL v3
  * Text Domain: lazy-load-for-videos
@@ -33,7 +33,7 @@ if ( !defined( 'LL_OPTION_KEY' ) ) {
 }
 
 if (!defined('LL_VERSION'))
-    define('LL_VERSION', '2.7.1');
+    define('LL_VERSION', '2.7.2');
 if (!defined('LL_VERSION_KEY'))
     define('LL_VERSION_KEY', LL_OPTION_KEY.'_version');
 
@@ -72,6 +72,7 @@ function lazyload_videos_init_plugins_loaded() {
 	require_once( LL_PATH . 'admin/class-admin-options.php' );
 	require_once( LL_PATH . 'frontend/class-frontend.php' );
 }
+
 add_action( 'plugins_loaded', 'lazyload_videos_init_plugins_loaded', 15 );
 
 
@@ -79,11 +80,13 @@ add_action( 'plugins_loaded', 'lazyload_videos_init_plugins_loaded', 15 );
 function lazyload_videos_admin_init() {
 	require_once( LL_PATH . 'admin/class-meta.php' );
 }
+
 function lazyload_videos_frontend_init() {
 	// Feature: Support for Widgets (Youtube only)
 	if ( (get_option('lly_opt_support_for_widgets') == true) ) {
 		require_once( LL_PATH . 'frontend/inc/support_for_widgets.php');
 	}
+
 	// Feature: Support for Plugin "TablePress"
 	if ( (get_option('ll_opt_support_for_tablepress') == true) ) {
 		require_once( LL_PATH . 'frontend/inc/support_for_tablepress.php');
@@ -92,8 +95,7 @@ function lazyload_videos_frontend_init() {
 
 if ( is_admin() ) {
 	add_action( 'plugins_loaded', 'lazyload_videos_admin_init', 16 );
-}
-else {
+} else {
 	add_action( 'plugins_loaded', 'lazyload_videos_frontend_init', 16 );
 }
 

--- a/frontend/class-frontend-css.php
+++ b/frontend/class-frontend-css.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package Frontend CSS
+ */
+class Lazy_Load_For_Videos_Init_CSS {
+	/**
+	 * Add CSS
+	 */
+	function enqueue() {
+		wp_enqueue_style( 'lazyload-video-css' );
+		
+		echo '<style type="text/css">';
+		
+		$this->load_lazyload_css_thumbnail_size();
+		$this->load_lazyload_css_video_titles();
+		$this->load_lazyload_css_button_style();
+		$this->load_lazyload_css_custom();
+
+		echo '</style>';
+	}
+
+	/**
+	 * Add Custom CSS
+	 */
+	function load_lazyload_css_custom() {
+		if (stripslashes(get_option('ll_opt_customcss')) != '') {
+			echo stripslashes(get_option('ll_opt_customcss'));
+		}
+	}
+
+	/**
+	 * Add CSS for thumbnails
+	 */
+	function load_lazyload_css_thumbnail_size() {
+		$thumbnail = get_option('ll_opt_thumbnail_size');
+		$classlist = '.entry-content a.lazy-load-youtube, a.lazy-load-youtube, .lazy-load-vimeo';
+
+    	if ($thumbnail == 'standard') {
+    		echo $classlist . '{ background-size: contain; }';
+    	} else if ($thumbnail == 'pattern-dots') {
+				echo $classlist . '{
+					background-color: #000;
+					background-image: radial-gradient(#333 15%, transparent 16%),
+					radial-gradient(#333 15%, transparent 16%);
+					background-size: 50px 50px;
+			    background-position: 0 0, 25px 25px;
+				}';
+			} else if ($thumbnail == 'pattern-light-s') {
+				echo $classlist . '{
+					background-color: #ccc;
+					background-image:
+					radial-gradient(circle at 100% 150%, #ccc 24%, white 25%, white 28%, #ccc 29%, #ccc 36%, white 36%, white 40%, transparent 40%, transparent),
+					radial-gradient(circle at 0 150%, #ccc 24%, white 25%, white 28%, #ccc 29%, #ccc 36%, white 36%, white 40%, transparent 40%, transparent),
+					radial-gradient(circle at 50% 100%, white 10%, #ccc 11%, #ccc 23%, white 24%, white 30%, #ccc 31%, #ccc 43%, white 44%, white 50%, #ccc 51%, #ccc 63%, white 64%, white 71%, transparent 71%, transparent),
+					radial-gradient(circle at 100% 50%, white 5%, #ccc 6%, #ccc 15%, white 16%, white 20%, #ccc 21%, #ccc 30%, white 31%, white 35%, #ccc 36%, #ccc 45%, white 46%, white 49%, transparent 50%, transparent),
+					radial-gradient(circle at 0 50%, white 5%, #ccc 6%, #ccc 15%, white 16%, white 20%, #ccc 21%, #ccc 30%, white 31%, white 35%, #ccc 36%, #ccc 45%, white 46%, white 49%, transparent 50%, transparent);
+					background-size:100px 50px;
+				}';
+			} else if ($thumbnail == 'pattern-carbon') {
+				echo $classlist . '{
+					background:
+					linear-gradient(27deg, #151515 5px, transparent 5px) 0 5px,
+					linear-gradient(207deg, #151515 5px, transparent 5px) 10px 0px,
+					linear-gradient(27deg, #222 5px, transparent 5px) 0px 10px,
+					linear-gradient(207deg, #222 5px, transparent 5px) 10px 5px,
+					linear-gradient(90deg, #1b1b1b 10px, transparent 10px),
+					linear-gradient(#1d1d1d 25%, #1a1a1a 25%, #1a1a1a 50%, transparent 50%, transparent 75%, #242424 75%, #242424);
+					background-color: #131313;
+					background-size: 20px 20px;
+				}';
+			} else if ($thumbnail == 'none') {
+				// No background, no thumbnail
+			} else {
+				echo $classlist . '{ background-size: cover; }';
+			}
+	}
+
+	/**
+	 * Add CSS to hide Video titles
+	 */
+	function load_lazyload_css_video_titles() {
+		// Hide Youtube titles with CSS
+    	if ( get_option('lly_opt_title') == false ) {
+    		echo '.titletext.youtube { display: none; }';
+    	}
+	}
+
+	/**
+	 * Change play button style
+	 */
+	function load_lazyload_css_button_style() {
+    	if ( get_option('ll_opt_button_style') == 'youtube_button_image' ) {
+    		// Display youtube button image
+    		echo '.lazy-load-div { background: url('.plugin_dir_url( __FILE__ ).'../assets/play-youtube.png) center center no-repeat; }';
+    		// ... and remove CSS-only content
+    		echo $this->load_css_button_selectors() . ' { content: ""; }';
+    	}
+    	else if ( get_option('ll_opt_button_style') == 'youtube_button_image_red' ) {
+    		// Display RED youtube button image
+    		echo '.lazy-load-div { background: url('.plugin_dir_url( __FILE__ ).'../assets/play-y-red.png) center center no-repeat; }';
+    		// ... and remove CSS-only content
+    		echo $this->load_css_button_selectors() . ' { content: ""; }';
+    	}
+    	else if (
+    			get_option('ll_opt_button_style') == 'css_black'
+    			|| get_option('ll_opt_button_style') == 'css_black_pulse'
+    		) {
+    		echo $this->load_css_button_selectors() . ' { color: #000; text-shadow: none; }';
+    		echo $this->load_css_button_selectors(':hover') . ' { text-shadow: none; }';
+    	}
+	}
+
+	/**
+	 * Little helper funtion to return the needed selectors for the play buttons
+	 */
+	private function load_css_button_selectors( $add = '' ) {
+		return ".lazy-load-div{$add}:before";
+	}
+}

--- a/frontend/class-frontend-init-scripts.php
+++ b/frontend/class-frontend-init-scripts.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @package Frontend – Init Scripts
+ */
+class Lazy_Load_For_Videos_Init_Scripts {
+	function init() {
+		$isDebugging = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG;
+		$areBothVideosEnabled = (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1');
+
+		if ($isDebugging || $areBothVideosEnabled) {
+			// "lazyload-video-js" is a script combining Vimeo and Youtube
+			wp_enqueue_script( 'lazyload-video-js');
+			$this->enqueued_vimeo = true;
+			$this->enqueued_youtube = true;
+		}
+
+		$settings = array();
+
+		if (get_option('lly_opt') !== '1') {
+			require( LL_PATH . 'frontend/class-youtube.php' );
+			$youtube = new Lazy_Load_For_Videos_Youtube();
+			
+			if (!$this->enqueued_youtube) {
+				$youtube->enqueue();
+				$this->enqueued_youtube = true;
+			}
+
+			$settings_youtube = array(
+				'youtube' => $youtube->get_js_settings()
+			);
+			$settings = array_merge($settings, $settings_youtube);
+
+		}
+		
+		if (get_option('llv_opt') !== '1') {
+			require( LL_PATH . 'frontend/class-vimeo.php' );
+			$vimeo = new Lazy_Load_For_Videos_Vimeo();
+
+			if (!$this->enqueued_vimeo) {
+				$vimeo->enqueue();
+				$this->enqueued_vimeo = true;
+			}
+
+			$settings_vimeo = array(
+				'vimeo' => $vimeo->get_js_settings()
+			);
+			$settings = array_merge($settings, $settings_vimeo);
+		}
+
+		wp_localize_script( 'lazyload-video-js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload_vimeo_js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload_youtube_js', 'lazyload_video_settings', $settings );
+	}
+}

--- a/frontend/class-frontend-init-scripts.php
+++ b/frontend/class-frontend-init-scripts.php
@@ -3,6 +3,9 @@
  * @package Frontend – Init Scripts
  */
 class Lazy_Load_For_Videos_Init_Scripts {
+	private $enqueued_vimeo = false;
+	private $enqueued_youtube = false;
+
 	function init() {
 		$isDebugging = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG;
 		$areBothVideosEnabled = (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1');
@@ -48,7 +51,7 @@ class Lazy_Load_For_Videos_Init_Scripts {
 		}
 
 		wp_localize_script( 'lazyload-video-js', 'lazyload_video_settings', $settings );
-		wp_localize_script( 'lazyload_vimeo_js', 'lazyload_video_settings', $settings );
-		wp_localize_script( 'lazyload_youtube_js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload-vimeo-js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload-youtube-js', 'lazyload_video_settings', $settings );
 	}
 }

--- a/frontend/class-frontend-init-scripts.php
+++ b/frontend/class-frontend-init-scripts.php
@@ -7,10 +7,10 @@ class Lazy_Load_For_Videos_Init_Scripts {
 	private $enqueued_youtube = false;
 
 	function init() {
-		$isDebugging = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG;
-		$areBothVideosEnabled = (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1');
-
-		if ($isDebugging || $areBothVideosEnabled) {
+		$isYoutubeEnabled = get_option('lly_opt') !== '1';
+		$isVimeoEnabled = get_option('llv_opt') !== '1';
+		
+		if ($isYoutubeEnabled && $isVimeoEnabled) {
 			// "lazyload-video-js" is a script combining Vimeo and Youtube
 			wp_enqueue_script( 'lazyload-video-js');
 			$this->enqueued_vimeo = true;
@@ -19,7 +19,7 @@ class Lazy_Load_For_Videos_Init_Scripts {
 
 		$settings = array();
 
-		if (get_option('lly_opt') !== '1') {
+		if ($isYoutubeEnabled) {
 			require( LL_PATH . 'frontend/class-youtube.php' );
 			$youtube = new Lazy_Load_For_Videos_Youtube();
 			
@@ -35,7 +35,7 @@ class Lazy_Load_For_Videos_Init_Scripts {
 
 		}
 		
-		if (get_option('llv_opt') !== '1') {
+		if ($isVimeoEnabled) {
 			require( LL_PATH . 'frontend/class-vimeo.php' );
 			$vimeo = new Lazy_Load_For_Videos_Vimeo();
 

--- a/frontend/class-frontend-init-styles.php
+++ b/frontend/class-frontend-init-styles.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * @package Frontend CSS
+ * @package Frontend – Init Styles
  */
-class Lazy_Load_For_Videos_Init_CSS {
+class Lazy_Load_For_Videos_Init_Styles {
 	/**
 	 * Add CSS
 	 */
-	function enqueue() {
+	function init() {
 		wp_enqueue_style( 'lazyload-video-css' );
 		
 		echo '<style type="text/css">';

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1,83 +1,20 @@
-<?php require_once( LL_PATH . 'frontend/class-frontend-css.php' );
+<?php
+require_once( LL_PATH . 'frontend/class-frontend-init-styles.php' );
+require_once( LL_PATH . 'frontend/class-frontend-init-scripts.php' );
 
 /**
  * @package Frontend
  */
-function lazyload_videos_register_scripts() {
-	// wp_deregister_script('jquery'); // <= For development: Deregister jQuery to ensure this plugin works without jQuery
-	wp_register_style( 'lazyload-video-css', LL_URL . 'assets/css/lazyload-all.css' );
-	wp_register_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
-	wp_register_script( 'lazyload_vimeo_js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
-	wp_register_script( 'lazyload_youtube_js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
-}
-
-add_action( 'wp_enqueue_scripts', 'lazyload_videos_register_scripts' );
-
-class Lazy_Load_For_Videos_Init_Scripts {
-
-	private $enqueued_css = false;
+class Lazy_Load_For_Videos_Frontend {
 	private $enqueued_vimeo = false;
 	private $enqueued_youtube = false;
 
-	function load_lazyload_css() {
-		if ($this->enqueued_css) return;
-
-		$css = new Lazy_Load_For_Videos_Init_CSS();
-		$css->enqueue();
-		$this->enqueued_css = true;
-	}
-
-	function init() {
-		if (!$this->should_scripts_be_loaded()) return;
-
-		$this->load_lazyload_css();
-
-		$isDebugging = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG;
-		$areBothVideosEnabled = (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1');
-
-		if ($isDebugging || $areBothVideosEnabled) {
-			// "lazyload-video-js" is a script combining Vimeo and Youtube
-			wp_enqueue_script( 'lazyload-video-js');
-			$this->enqueued_vimeo = true;
-			$this->enqueued_youtube = true;
-		}
-
-		$settings = array();
-
-		if (get_option('lly_opt') !== '1') {
-			require( LL_PATH . 'frontend/class-youtube.php' );
-			$youtube = new Lazy_Load_For_Videos_Youtube();
-			
-			if (!$this->enqueued_youtube) {
-				$youtube->enqueue();
-				$this->enqueued_youtube = true;
-			}
-
-			$settings_youtube = array(
-				'youtube' => $youtube->get_js_settings()
-			);
-			$settings = array_merge($settings, $settings_youtube);
-
-		}
-		
-		if (get_option('llv_opt') !== '1') {
-			require( LL_PATH . 'frontend/class-vimeo.php' );
-			$vimeo = new Lazy_Load_For_Videos_Vimeo();
-
-			if (!$this->enqueued_vimeo) {
-				$vimeo->enqueue();
-				$this->enqueued_vimeo = true;
-			}
-
-			$settings_vimeo = array(
-				'vimeo' => $vimeo->get_js_settings()
-			);
-			$settings = array_merge($settings, $settings_vimeo);
-		}
-
-		wp_localize_script( 'lazyload-video-js', 'lazyload_video_settings', $settings );
-		wp_localize_script( 'lazyload_vimeo_js', 'lazyload_video_settings', $settings );
-		wp_localize_script( 'lazyload_youtube_js', 'lazyload_video_settings', $settings );
+	function registerAll() {
+		// wp_deregister_script('jquery'); // <= For development: Deregister jQuery to ensure this plugin works without jQuery
+		wp_register_style( 'lazyload-video-css', LL_URL . 'assets/css/lazyload-all.css' );
+		wp_register_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
+		wp_register_script( 'lazyload_vimeo_js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
+		wp_register_script( 'lazyload_youtube_js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
 	}
 
 	/**
@@ -110,8 +47,17 @@ class Lazy_Load_For_Videos_Init_Scripts {
 }
 
 function lazyload_videos_frontend() {
-	$scripts = new Lazy_Load_For_Videos_Init_Scripts();
-	$scripts->init();
+	$frontend = new Lazy_Load_For_Videos_Frontend();
+
+	if ($frontend->should_scripts_be_loaded()) {
+		$frontend->registerAll();
+
+		$styles = new Lazy_Load_For_Videos_Init_Styles();
+		$styles->init();
+
+		$scripts = new Lazy_Load_For_Videos_Init_Scripts();
+		$scripts->init();
+	}
 }
 
 add_action( 'wp_enqueue_scripts', 'lazyload_videos_frontend' );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -45,8 +45,9 @@ class Lazy_Load_For_Videos_Frontend {
 
 function lazyload_videos_frontend() {
 	$frontend = new Lazy_Load_For_Videos_Frontend();
+	$should_load_scripts = apply_filters( 'lazyload_videos_should_scripts_be_loaded', $frontend->should_scripts_be_loaded());
 
-	if ($frontend->should_scripts_be_loaded()) {
+	if ($should_load_scripts) {
 		$frontend->registerAll();
 
 		$styles = new Lazy_Load_For_Videos_Init_Styles();

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -6,15 +6,12 @@ require_once( LL_PATH . 'frontend/class-frontend-init-scripts.php' );
  * @package Frontend
  */
 class Lazy_Load_For_Videos_Frontend {
-	private $enqueued_vimeo = false;
-	private $enqueued_youtube = false;
-
 	function registerAll() {
 		// wp_deregister_script('jquery'); // <= For development: Deregister jQuery to ensure this plugin works without jQuery
 		wp_register_style( 'lazyload-video-css', LL_URL . 'assets/css/lazyload-all.css' );
 		wp_register_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
-		wp_register_script( 'lazyload_vimeo_js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
-		wp_register_script( 'lazyload_youtube_js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
+		wp_register_script( 'lazyload-vimeo-js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
+		wp_register_script( 'lazyload-youtube-js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1,185 +1,117 @@
-<?php
+<?php require_once( LL_PATH . 'frontend/class-frontend-css.php' );
+
 /**
  * @package Frontend
  */
-class Lazy_Load_For_Videos_Frontend {
+function lazyload_videos_register_scripts() {
+	// wp_deregister_script('jquery'); // <= For development: Deregister jQuery to ensure this plugin works without jQuery
+	wp_register_style( 'lazyload-video-css', LL_URL . 'assets/css/lazyload-all.css' );
+	wp_register_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
+	wp_register_script( 'lazyload_vimeo_js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
+	wp_register_script( 'lazyload_youtube_js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
+}
+
+add_action( 'wp_enqueue_scripts', 'lazyload_videos_register_scripts' );
+
+class Lazy_Load_For_Videos_Init_Scripts {
+
+	private $enqueued_css = false;
+	private $enqueued_vimeo = false;
+	private $enqueued_youtube = false;
+
+	function load_lazyload_css() {
+		if ($this->enqueued_css) return;
+
+		$css = new Lazy_Load_For_Videos_Init_CSS();
+		$css->enqueue();
+		$this->enqueued_css = true;
+	}
 
 	function init() {
-		if ( $this->test_if_scripts_should_be_loaded() ) {
-			$this->load_lazyload_style();
-			add_action( 'wp_head', array( $this, 'load_lazyload_css') );
+		if (!$this->should_scripts_be_loaded()) return;
 
-			if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-				wp_enqueue_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
-			} else if ( (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1') ) {
-				wp_enqueue_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-all.js', null, LL_VERSION, true );
+		$this->load_lazyload_css();
+
+		$isDebugging = defined('SCRIPT_DEBUG') && SCRIPT_DEBUG;
+		$areBothVideosEnabled = (get_option('lly_opt') !== '1') && (get_option('llv_opt') !== '1');
+
+		if ($isDebugging || $areBothVideosEnabled) {
+			// "lazyload-video-js" is a script combining Vimeo and Youtube
+			wp_enqueue_script( 'lazyload-video-js');
+			$this->enqueued_vimeo = true;
+			$this->enqueued_youtube = true;
+		}
+
+		$settings = array();
+
+		if (get_option('lly_opt') !== '1') {
+			require( LL_PATH . 'frontend/class-youtube.php' );
+			$youtube = new Lazy_Load_For_Videos_Youtube();
+			
+			if (!$this->enqueued_youtube) {
+				$youtube->enqueue();
+				$this->enqueued_youtube = true;
 			}
 
-            $settings = array();
+			$settings_youtube = array(
+				'youtube' => $youtube->get_js_settings()
+			);
+			$settings = array_merge($settings, $settings_youtube);
 
-            if (get_option('lly_opt') !== '1') {
-                require( LL_PATH . 'frontend/class-youtube.php' );
-                $youtube = new Lazy_Load_For_Videos_Youtube();
-                $youtube->init();
-
-                $settings_youtube = array(
-                    'youtube' => $youtube->get_js_settings()
-                );
-                $settings = array_merge($settings, $settings_youtube);
-
-            }
-            if (get_option('llv_opt') !== '1') {
-                require( LL_PATH . 'frontend/class-vimeo.php' );
-                $vimeo = new Lazy_Load_For_Videos_Vimeo();
-                $vimeo->init();
-
-                $settings_vimeo = array(
-                    'vimeo' => $vimeo->get_js_settings()
-                );
-                $settings = array_merge($settings, $settings_vimeo);
-            }
-
-			wp_localize_script( 'lazyload-video-js', 'lazyload_video_settings', $settings );
 		}
-	}
+		
+		if (get_option('llv_opt') !== '1') {
+			require( LL_PATH . 'frontend/class-vimeo.php' );
+			$vimeo = new Lazy_Load_For_Videos_Vimeo();
 
-	/**
-	 * Add stylesheet
-	 */
-	function load_lazyload_style() {
-		wp_register_style( 'lazyload-style', plugins_url('assets/css/lazyload-all.css', plugin_dir_path( __FILE__ )) );
-		wp_enqueue_style( 'lazyload-style' );
-	}
-
-	/**
-	 * Add CSS
-	 */
-	function load_lazyload_css() {
-		echo '<style type="text/css">';
-
-		$this->load_lazyload_css_thumbnail_size();
-		$this->load_lazyload_css_video_titles();
-		$this->load_lazyload_css_button_style();
-		$this->load_lazyload_css_custom();
-
-		echo '</style>';
-	}
-
-	/**
-	 * Add Custom CSS
-	 */
-	function load_lazyload_css_custom() {
-		if (stripslashes(get_option('ll_opt_customcss')) != '') {
-			echo stripslashes(get_option('ll_opt_customcss'));
-		}
-	}
-
-	/**
-	 * Add CSS for thumbnails
-	 */
-	function load_lazyload_css_thumbnail_size() {
-		$thumbnail = get_option('ll_opt_thumbnail_size');
-		$classlist = '.entry-content a.lazy-load-youtube, a.lazy-load-youtube, .lazy-load-vimeo';
-
-    	if ($thumbnail == 'standard') {
-    		echo $classlist . '{ background-size: contain; }';
-    	} else if ($thumbnail == 'pattern-dots') {
-				echo $classlist . '{
-					background-color: #000;
-					background-image: radial-gradient(#333 15%, transparent 16%),
-					radial-gradient(#333 15%, transparent 16%);
-					background-size: 50px 50px;
-			    background-position: 0 0, 25px 25px;
-				}';
-			} else if ($thumbnail == 'pattern-light-s') {
-				echo $classlist . '{
-					background-color: #ccc;
-					background-image:
-					radial-gradient(circle at 100% 150%, #ccc 24%, white 25%, white 28%, #ccc 29%, #ccc 36%, white 36%, white 40%, transparent 40%, transparent),
-					radial-gradient(circle at 0 150%, #ccc 24%, white 25%, white 28%, #ccc 29%, #ccc 36%, white 36%, white 40%, transparent 40%, transparent),
-					radial-gradient(circle at 50% 100%, white 10%, #ccc 11%, #ccc 23%, white 24%, white 30%, #ccc 31%, #ccc 43%, white 44%, white 50%, #ccc 51%, #ccc 63%, white 64%, white 71%, transparent 71%, transparent),
-					radial-gradient(circle at 100% 50%, white 5%, #ccc 6%, #ccc 15%, white 16%, white 20%, #ccc 21%, #ccc 30%, white 31%, white 35%, #ccc 36%, #ccc 45%, white 46%, white 49%, transparent 50%, transparent),
-					radial-gradient(circle at 0 50%, white 5%, #ccc 6%, #ccc 15%, white 16%, white 20%, #ccc 21%, #ccc 30%, white 31%, white 35%, #ccc 36%, #ccc 45%, white 46%, white 49%, transparent 50%, transparent);
-					background-size:100px 50px;
-				}';
-			} else if ($thumbnail == 'pattern-carbon') {
-				echo $classlist . '{
-					background:
-					linear-gradient(27deg, #151515 5px, transparent 5px) 0 5px,
-					linear-gradient(207deg, #151515 5px, transparent 5px) 10px 0px,
-					linear-gradient(27deg, #222 5px, transparent 5px) 0px 10px,
-					linear-gradient(207deg, #222 5px, transparent 5px) 10px 5px,
-					linear-gradient(90deg, #1b1b1b 10px, transparent 10px),
-					linear-gradient(#1d1d1d 25%, #1a1a1a 25%, #1a1a1a 50%, transparent 50%, transparent 75%, #242424 75%, #242424);
-					background-color: #131313;
-					background-size: 20px 20px;
-				}';
-			} else if ($thumbnail == 'none') {
-				// No background, no thumbnail
-			} else {
-				echo $classlist . '{ background-size: cover; }';
+			if (!$this->enqueued_vimeo) {
+				$vimeo->enqueue();
+				$this->enqueued_vimeo = true;
 			}
+
+			$settings_vimeo = array(
+				'vimeo' => $vimeo->get_js_settings()
+			);
+			$settings = array_merge($settings, $settings_vimeo);
+		}
+
+		wp_localize_script( 'lazyload-video-js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload_vimeo_js', 'lazyload_video_settings', $settings );
+		wp_localize_script( 'lazyload_youtube_js', 'lazyload_video_settings', $settings );
 	}
 
 	/**
-	 * Add CSS to hide Video titles
+	 * Don't load scripts in specific circumstances
 	 */
-	function load_lazyload_css_video_titles() {
-		// Hide Youtube titles with CSS
-    	if ( get_option('lly_opt_title') == false ) {
-    		echo '.titletext.youtube { display: none; }';
-    	}
-	}
-
-	/**
-	 * Change play button style
-	 */
-	function load_lazyload_css_button_style() {
-    	if ( get_option('ll_opt_button_style') == 'youtube_button_image' ) {
-    		// Display youtube button image
-    		echo '.lazy-load-div { background: url('.plugin_dir_url( __FILE__ ).'../assets/play-youtube.png) center center no-repeat; }';
-    		// ... and remove CSS-only content
-    		echo $this->load_css_button_selectors() . ' { content: ""; }';
-    	}
-    	else if ( get_option('ll_opt_button_style') == 'youtube_button_image_red' ) {
-    		// Display RED youtube button image
-    		echo '.lazy-load-div { background: url('.plugin_dir_url( __FILE__ ).'../assets/play-y-red.png) center center no-repeat; }';
-    		// ... and remove CSS-only content
-    		echo $this->load_css_button_selectors() . ' { content: ""; }';
-    	}
-    	else if (
-    			get_option('ll_opt_button_style') == 'css_black'
-    			|| get_option('ll_opt_button_style') == 'css_black_pulse'
-    		) {
-    		echo $this->load_css_button_selectors() . ' { color: #000; text-shadow: none; }';
-    		echo $this->load_css_button_selectors(':hover') . ' { text-shadow: none; }';
-    	}
-	}
-
-	/**
-	 * Little helper funtion to return the needed selectors for the play buttons
-	 */
-	private function load_css_button_selectors( $add = '' ) {
-		return ".lazy-load-div{$add}:before";
-	}
-
-	/**
-	 * Don't load scripts on specific circumstances
-	 */
-	function test_if_scripts_should_be_loaded() {
+	function should_scripts_be_loaded() {
+		if (
+			( get_option('ll_opt_load_scripts') != '1' ) ||	// Option "Only load CSS/JS when needed" is NOT checked
+			( get_option('lly_opt_support_for_widgets') == true ) // Always load scripts if widgets need lazy load support (Youtube only)
+		) {
+			return true;
+		}
+		
 		global $lazyload_videos_general;
+		if (is_singular()) {
+			$post_id = absint(get_the_ID());
+			return $lazyload_videos_general->has_post_or_page_embed($post_id);
+		}
+		
+		// For pages with multiple posts (e.g. homepage and archives),
+		// iterate over all posts to see if any of them includes an embed.
+		global $posts;
+		foreach($posts as $post) {
+			$has_post_embed = $lazyload_videos_general->has_post_or_page_embed($post->ID);
+			if ($has_post_embed) return true;
+		};
 
-		return
-			( get_option('ll_opt_load_scripts') != '1' ) ||	// Option "Support for Widgets (Youtube only)" is checked
-			( get_option('lly_opt_support_for_widgets') == true ) ||	// Option "Support for Widgets (Youtube only)" is checked
-			( is_singular() && ($lazyload_videos_general->test_if_post_or_page_has_embed()) )	// Pages/posts with oembedded media
-			//|| ( !is_singular() )	// Everything else (except for pages/posts without oembedded media)
-		? true : false;
+		return false;
 	}
 }
 
-function initialize_lazyload_frontend() {
-	$frontend = new Lazy_Load_For_Videos_Frontend();
-	$frontend->init();
+function lazyload_videos_frontend() {
+	$scripts = new Lazy_Load_For_Videos_Init_Scripts();
+	$scripts->init();
 }
-add_action( 'wp_enqueue_scripts', 'initialize_lazyload_frontend' );
+
+add_action( 'wp_enqueue_scripts', 'lazyload_videos_frontend' );

--- a/frontend/class-vimeo.php
+++ b/frontend/class-vimeo.php
@@ -4,12 +4,8 @@
  */
 class Lazy_Load_For_Videos_Vimeo {
 
-	public function init() {
-		if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-			wp_enqueue_script( 'lazyload_vimeo_js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
-		} else if ( get_option('llv_opt') !== '1' ) {
-			wp_enqueue_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-vimeo.js', null, LL_VERSION, true );
-		}
+	function enqueue() {
+		wp_enqueue_script( 'lazyload_vimeo_js');
 	}
 
 	/**

--- a/frontend/class-vimeo.php
+++ b/frontend/class-vimeo.php
@@ -5,7 +5,7 @@
 class Lazy_Load_For_Videos_Vimeo {
 
 	function enqueue() {
-		wp_enqueue_script( 'lazyload_vimeo_js');
+		wp_enqueue_script( 'lazyload-vimeo-js');
 	}
 
 	/**

--- a/frontend/class-youtube.php
+++ b/frontend/class-youtube.php
@@ -5,7 +5,7 @@
 class Lazy_Load_For_Videos_Youtube {
 	
 	function enqueue() {
-		wp_enqueue_script( 'lazyload_youtube_js');
+		wp_enqueue_script( 'lazyload-youtube-js');
 	}
 
 	/**

--- a/frontend/class-youtube.php
+++ b/frontend/class-youtube.php
@@ -3,13 +3,9 @@
  * @package Lazyload Youtube
  */
 class Lazy_Load_For_Videos_Youtube {
-
-	public function init() {
-		if ( defined('SCRIPT_DEBUG') && SCRIPT_DEBUG ) {
-			wp_enqueue_script( 'lazyload_youtube_js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
-		} else if ( get_option('lly_opt') !== '1' ) {
-			wp_enqueue_script( 'lazyload-video-js', LL_URL . 'assets/js/lazyload-youtube.js', null, LL_VERSION, true );
-		}
+	
+	function enqueue() {
+		wp_enqueue_script( 'lazyload_youtube_js');
 	}
 
 	/**

--- a/inc/class-general.php
+++ b/inc/class-general.php
@@ -8,17 +8,8 @@ class Lazy_Load_For_Videos_General {
 	private $thumbnailquality_default = '0';
 	private $thumbnailquality_maxresdefault = 'maxresdefault';
 
-	/**
-	 * Thanks to http://t31os.wordpress.com/2010/05/24/post-has-embed/ for a nicer solution than mine
-	 */
-	function test_if_post_or_page_has_embed( $post_id = false ) {
-	    if( !$post_id )
-	        $post_id = get_the_ID();
-	    else
-	        $post_id = absint( $post_id );
-	    if( !$post_id )
-	        return false;
-
+	function has_post_or_page_embed( $post_id ) {
+		
 	 	// Get meta keys for current post
 	    $post_meta = get_post_custom_keys( $post_id );
 	 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1603,15 +1603,23 @@
       }
     },
     "babel-loader": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.5.tgz",
-      "integrity": "sha512-NTnHnVRd2JnRqPC0vW+iOQWU5pchDbYXsG2E6DMXEpMfUcQKclF9gmf3G3ZMhzG7IG9ji4coL0cm+FxeWxDpnw==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+      "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^2.0.0",
         "loader-utils": "^1.0.2",
         "mkdirp": "^0.5.1",
-        "util.promisify": "^1.0.0"
+        "pify": "^4.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "babel-plugin-istanbul": {
@@ -4223,9 +4231,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8805,13 +8813,13 @@
       "dev": true
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-env": "^7.4.4",
     "autoprefixer": "^8.6.5",
     "babel-eslint": "^10.0.1",
-    "babel-loader": "^8.0.5",
+    "babel-loader": "^8.0.6",
     "css-loader": "^2.1.1",
     "eslint": "^5.3.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/readme.txt
+++ b/readme.txt
@@ -147,7 +147,9 @@ Note that playlists are not working when you're using the pre-/post-roll feature
 == Changelog ==
 
 = 2.7.2 =
-* Improve "Only load CSS/JS when needed" feature by checking for embeds on pages with multiple posts (e.g. homepage, archive).
+* Improve "Only load CSS/JS when needed" feature by scanning for embeds on pages with multiple posts (e.g. homepage, archive).
+* Add filter: lazyload_videos_should_scripts_be_loaded
+* No longer support "SCRIPT_DEBUG" variable for development
 
 = 2.7.0 =
 * ️️⚡ Performance: Independence from jQuery! The user-facing part of this plugin no longer requires jQuery.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.kweber.com/donate/LazyLoadVideos/
 Tags: youtube, vimeo, performance, seo, admin, plugin, content, video, mobile, lazy load, privacy
 Requires at least: 3.5
 Tested up to: 5.2.0
-Stable tag: 2.7.1
+Stable tag: 2.7.2
 License: GPL v3
 License URI: https://www.gnu.org/copyleft/gpl.html
 
@@ -141,6 +141,9 @@ Note that playlists are not working when you're using the pre-/post-roll feature
 
 
 == Changelog ==
+
+= 2.7.2 =
+* Improve "Only load CSS/JS when needed" feature by checking for embeds on pages with multiple posts (e.g. homepage, archive).
 
 = 2.7.0 =
 * ️️⚡ Performance: Independence from jQuery! The user-facing part of this plugin no longer requires jQuery.

--- a/readme.txt
+++ b/readme.txt
@@ -122,15 +122,19 @@ add_action( 'lazyload_videos_post_types', 'lazyload_videos_set_post_types' );`
 
 = How to use a custom play button? =
 For now, you can choose the "Youtube button image" from the play button drop-down list, then add the following custom CSS that includes a link to your custom CSS play button image:
-`.preview-youtube .lazy-load-youtube-div, .lazy-load-vimeo-div {
+
+```
+.preview-youtube .lazy-load-youtube-div, .lazy-load-vimeo-div {
 	background-image: url(INSERT-YOUR-URL-HERE.../images/play.png);
-}`
+}
+```
+
 Feature versions might include an option to change the colour of your CSS-only buttons using a colour picker and might also include an option to directly upload the desired button image.
 
 = How to lazy load playlists? =
 Similar to a single video, insert the playlist URL in the following format:
 `https://www.youtube.com/watch?v=dkfQFih23Ak&list=PLRQFBJ3mkjnxaPhAVOzjxxv_0yr8XE0Ja` (the other format - `https://www.youtube.com/playlist?list=...` - is not supported currently).
-Note that playlists are not working when you're using the pre-/post-roll feature yet.
+Note that playlists are not working when you're using the pre-/post-roll feature.
 
 = Known bugs - this plugin may not work correctly when one of the following plugins is activated... =
 * "YouTube" (https://wordpress.org/extend/plugins/youtube-embed-plus/)


### PR DESCRIPTION
### Improve embed detection

```
// For pages with multiple posts (e.g. homepage and archives),
// iterate over all posts to see if any of them includes an embed.
global $posts;
foreach($posts as $post) {
    $has_post_embed = $lazyload_videos_general->has_post_or_page_embed($post->ID);
    if ($has_post_embed) return true;
};
```

### New filter: `lazyload_videos_should_scripts_be_loaded`

You can override when the JS and CSS of this plugin should be loaded. If you always return `true` as shown in the example below, the scripts will always be loaded, no matter if the page has a video embed or not.

```
function custom_theme_plugin__should_scripts_be_loaded($value) {
	// return $value;
	return true; // <- Always load scripts, no matter what page you're on
}
add_filter( 'lazyload_videos_should_scripts_be_loaded', 'custom_theme_plugin__should_scripts_be_loaded');
```

Imagine the following scenario:
1. User navigates to page without video. No lazy video script is loaded.
2. The site uses Ajax to load posts and pages without a page refresh.
3. The user navigates to a different post that includes a video.
4. The video doesn't show because the video script isn't loaded.

This can be avoided by loading the lazy video script during the initial page load, no matter if the initial page has a video or not. Above filter allows you to achieve exactly that.