### PR TITLE
Updated video.js file for variable video ratio

### DIFF
--- a/modules/shared/video.js
+++ b/modules/shared/video.js
@@ -22,7 +22,10 @@ function determineVideoRatio(element) {
     );
     const ratioraw = ratioclass.replace('wp-embed-aspect-', '');
     const splitratio = ratioraw.split('-');
-    return Number(splitratio[1]) / Number(splitratio[0]);
+    const result = Number(splitratio[1]) / Number(splitratio[0]);
+    const countDec = result.toString().split('.')[1].length;
+    if (countDec > 4) { return (Math.round(result * 10000) / 10000); }
+    return result;
   }
   return 0.5625; // <-- default
 }

--- a/modules/shared/video.js
+++ b/modules/shared/video.js
@@ -11,13 +11,30 @@ export function setBackgroundImage(element, imageUrl) {
   element.setAttribute('style', `background-image:url(${imageUrl});background-color:#000;background-position:center center;background-repeat:no-repeat;`);
 }
 
+function determineVideoRatio(element) {
+  const parent = element && element.parentNode && element.parentNode.parentNode;
+  const hasAspectRatioClass = parent && parent.classList.contains('wp-has-aspect-ratio');
+  if (hasAspectRatioClass) {
+    const classes = String(parent.classList);
+    const ratioclass = classes.substring(
+      classes.lastIndexOf('wp-embed-aspect-'),
+      classes.lastIndexOf(' '),
+    );
+    const ratioraw = ratioclass.replace('wp-embed-aspect-', '');
+    const splitratio = ratioraw.split('-');
+    return Number(splitratio[1]) / Number(splitratio[0]);
+  }
+  return 0.5625; // <-- default
+}
+
 const debouncedResize = debounce(() => {
   findElements('.container-lazyload').forEach((domContainerItem) => {
+    const videoRatio = determineVideoRatio(domContainerItem);
     findElements('object, embed, iframe, .preview-lazyload, .lazy-load-div', domContainerItem)
       .forEach((domItem) => {
         const element = domItem;
         const width = element.parentNode.clientWidth;
-        const height = Math.round(width * videoratio);
+        const height = Math.round(width * videoRatio);
 
         element.setAttribute('height', `${height}px`);
         element.setAttribute('width', `${width}px`);


### PR DESCRIPTION
Variable size (ratio) for all video embeds. Testet with a striped down (CSS only) Twenty Nineteen Theme and Wordpress WordPress 5.2.1. A solution for Issue #22. Better solution than last try (ac33989e7b30db3bcce352caae68c686aec98822). Please ignore last pull request from today! :-)