### PR TITLE
Get full size Vimeo preview image

### DIFF
--- a/src/frontend/lazyload-vimeo/lazyloadVimeo.js
+++ b/src/frontend/lazyload-vimeo/lazyloadVimeo.js
@@ -59,9 +59,14 @@ function vimeoLoadingThumb(videoLinkElement, id) {
   videoLinkElement.appendChild(playButtonDiv);
 
   if (window.llvConfig.vimeo.loadthumbnail) {
-    const videoThumbnail = videoLinkElement.getAttribute(
+    var videoThumbnail = videoLinkElement.getAttribute(
       'data-video-thumbnail',
     );
+    
+    if (videoThumbnail.indexOf('_') !== -1) { 
+      videoThumbnail = videoThumbnail.split('_')[0] + '.jpg';
+    }
+    
     if (videoThumbnail) {
       inViewOnce(findElements(`[id="${id}"]`), (element) => setBackgroundImage(element, videoThumbnail));
     } else {


### PR DESCRIPTION
This is quite simple, just trims the size from the end of the thumbnail URL to get a full resolution thumbnail (sometimes that may be a little bigger than we want, but I think it's an improvement from serving 300px wide previews in many cases). If the URL doesn't have an underscore in it, works the same as before, just using the URL directly.

Tested this in the built code and copied here, have not directly tested.