### PR TITLE
Update to WordPress default tab styling

### DIFF
--- a/src/frontend/admin/admin-options.js
+++ b/src/frontend/admin/admin-options.js
@@ -42,3 +42,10 @@ const init = () => {
 $(document).ready(() => {
   init();
 });
+// EJ add new tabs code
+$(document).ready(() => {
+  $('li').click(function addActive() {
+      $('li.nav-tab.nav-tab-active').removeClass('nav-tab-active');
+      $(this).addClass('nav-tab-active');
+  });
+});

--- a/src/frontend/admin/admin-options.scss
+++ b/src/frontend/admin/admin-options.scss
@@ -288,3 +288,8 @@ input.regular-text {
 .clear-both {
 	clear: both;
 }
+
+// Remove bottom margin on "new" tabs
+li.nav-tab {
+  margin-bottom: 0;
+}

--- a/src/php/class-admin-options.php
+++ b/src/php/class-admin-options.php
@@ -172,7 +172,7 @@ class KW_LLV_Admin {
 			</h2>
 
 			<ul class="nav-tab-wrapper">
-				<li class="nav-tab"><a href="#general"><?php esc_html_e('General/Styling', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
+				<li class="nav-tab nav-tab-active"><a href="#general"><?php esc_html_e('General/Styling', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
 				<li class="nav-tab"><a href="#youtube"><?php esc_html_e('YouTube', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
 				<li class="nav-tab"><a href="#vimeo"><?php esc_html_e('Vimeo', LL_TD); ?></a></li>
 				<?php do_action('lazyload_settings_page_tabs_link_after'); ?>

--- a/src/php/class-admin-options.php
+++ b/src/php/class-admin-options.php
@@ -172,11 +172,11 @@ class KW_LLV_Admin {
 			</h2>
 
 			<ul class="ui-tabs-nav">
-		        <li><a href="#general"><?php esc_html_e( 'General/Styling', LL_TD ); ?><span class="newred_dot">&bull;</span></a></li>
-		        <li><a href="#youtube"><?php esc_html_e( 'YouTube', LL_TD ); ?><span class="newred_dot">&bull;</span></a></li>
-		    	<li><a href="#vimeo"><?php esc_html_e( 'Vimeo', LL_TD ); ?></a></li>
-		        <?php do_action( 'lazyload_settings_page_tabs_link_after' ); ?>
-		    </ul>
+				<li><a href="#general"><?php esc_html_e('General/Styling', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
+				<li><a href="#youtube"><?php esc_html_e('YouTube', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
+				<li><a href="#vimeo"><?php esc_html_e('Vimeo', LL_TD); ?></a></li>
+				<?php do_action('lazyload_settings_page_tabs_link_after'); ?>
+			</ul>
 
 			<form method="post" action="options.php">
 			<?php

--- a/src/php/class-admin-options.php
+++ b/src/php/class-admin-options.php
@@ -66,7 +66,7 @@ class KW_LLV_Admin {
 		if ( function_exists( 'amp_is_request' ) && amp_is_request() ) {
 			return $return;
 		}
-		
+
 		// Replacements don't work in feeds
 		if ( is_feed() ) {
 			return $return;
@@ -134,7 +134,7 @@ class KW_LLV_Admin {
 			'll_opt_customcss',
 			'll_opt_support_for_tablepress',
 			'll_attribute',
-			
+
 			// Youtube
 			'lly_opt',
 			'lly_opt_title',
@@ -146,7 +146,7 @@ class KW_LLV_Admin {
 			'lly_opt_player_controls',
 			'lly_opt_player_loadpolicy',
 			'lly_opt_cookies',
-			
+
 			// Vimeo
 			'llv_opt',
 			'llv_opt_title',
@@ -173,7 +173,7 @@ class KW_LLV_Admin {
 
 			<ul class="ui-tabs-nav">
 		        <li><a href="#general"><?php esc_html_e( 'General/Styling', LL_TD ); ?><span class="newred_dot">&bull;</span></a></li>
-		        <li><a href="#youtube"><?php esc_html_e( 'Youtube', LL_TD ); ?><span class="newred_dot">&bull;</span></a></li>
+		        <li><a href="#youtube"><?php esc_html_e( 'YouTube', LL_TD ); ?><span class="newred_dot">&bull;</span></a></li>
 		    	<li><a href="#vimeo"><?php esc_html_e( 'Vimeo', LL_TD ); ?></a></li>
 		        <?php do_action( 'lazyload_settings_page_tabs_link_after' ); ?>
 		    </ul>
@@ -360,7 +360,7 @@ class KW_LLV_Admin {
 					        <tr valign="top">
 						        <th scope="row"><label><?php esc_html_e( 'Disable Lazy Load for Vimeo', LL_TD ); ?></label></th>
 						        <td>
-									<input name="llv_opt" type="checkbox" value="1" <?php checked( '1', get_option( 'llv_opt' ) ); ?> /> 
+									<input name="llv_opt" type="checkbox" value="1" <?php checked( '1', get_option( 'llv_opt' ) ); ?> />
 									<label>
 										<?php printf( esc_html__( 'If checked, Lazy Load will not be used for %1$s videos.', LL_TD ),
 											'<b>Vimeo</b>'

--- a/src/php/class-admin-options.php
+++ b/src/php/class-admin-options.php
@@ -171,10 +171,10 @@ class KW_LLV_Admin {
 				<br><span class="claim" style="font-size:15px;font-style:italic;position:relative;top:-7px;"><?php esc_html_e( 'Speed up your site and customise your video player!', LL_TD ); ?></span>
 			</h2>
 
-			<ul class="ui-tabs-nav">
-				<li><a href="#general"><?php esc_html_e('General/Styling', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
-				<li><a href="#youtube"><?php esc_html_e('YouTube', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
-				<li><a href="#vimeo"><?php esc_html_e('Vimeo', LL_TD); ?></a></li>
+			<ul class="nav-tab-wrapper">
+				<li class="nav-tab"><a href="#general"><?php esc_html_e('General/Styling', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
+				<li class="nav-tab"><a href="#youtube"><?php esc_html_e('YouTube', LL_TD); ?><span class="newred_dot">&bull;</span></a></li>
+				<li class="nav-tab"><a href="#vimeo"><?php esc_html_e('Vimeo', LL_TD); ?></a></li>
 				<?php do_action('lazyload_settings_page_tabs_link_after'); ?>
 			</ul>
 
@@ -444,7 +444,7 @@ class KW_LLV_Admin {
 	}
 
 	function lazyload_admin_js() {
-		wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'public/js/admin.js', array('jquery', 'jquery-ui-tabs', 'wp-color-picker' ), LL_VERSION );
+		wp_enqueue_script( 'lazyload_admin_js', LL_URL . 'public/js/admin.js', array('jquery', /* 'jquery-ui-tabs', */ 'wp-color-picker' ), LL_VERSION );
 	}
 
 	function lazyload_admin_css() {


### PR DESCRIPTION
fixes #59 

This PR removes the jQuery UI tabs and replaces it with WordPress Core styling. I feel that as a hobbyist programmer/junior developer this will need some review before it is ready to merge. That said everything is working but I have not removed any of the old css styles yet.

Ready for feedback.